### PR TITLE
Updated the manifest for Flowkeeper v0.10.0

### DIFF
--- a/org.flowkeeper.Flowkeeper.yaml
+++ b/org.flowkeeper.Flowkeeper.yaml
@@ -92,6 +92,8 @@ modules:
     build-commands:
       - install -Dm755 run.sh /app/bin/run.sh
 
+      - python -m compileall .
+
       - desktop-file-edit --remove-key="Exec" --remove-key="Version" --remove-key="Icon" flowkeeper/installer/flowkeeper.desktop
       - desktop-file-edit --set-key="Exec" --set-value="run.sh" flowkeeper/installer/flowkeeper.desktop
       - install -Dm644 flowkeeper/installer/flowkeeper.desktop ${FLATPAK_DEST}/share/applications/flowkeeper.desktop

--- a/org.flowkeeper.Flowkeeper.yaml
+++ b/org.flowkeeper.Flowkeeper.yaml
@@ -92,14 +92,11 @@ modules:
     build-commands:
       - install -Dm755 run.sh /app/bin/run.sh
 
-      - desktop-file-edit --remove-key="Version" flowkeeper/installer/flowkeeper.desktop
+      - desktop-file-edit --remove-key="Exec" --remove-key="Version" --remove-key="Icon" flowkeeper/installer/flowkeeper.desktop
       - desktop-file-edit --set-key="Exec" --set-value="run.sh" flowkeeper/installer/flowkeeper.desktop
       - desktop-file-edit --remove-key="Icon" flowkeeper/installer/flowkeeper.desktop
       - install -Dm644 flowkeeper/installer/flowkeeper.desktop ${FLATPAK_DEST}/share/applications/flowkeeper.desktop
-
-      # org.flowkeeper.Flowkeeper.png is not a valid icon: Image too large (1024x1024). Max. size 512x512
-      # - install -Dm644 flowkeeper/res/flowkeeper.png /app/share/icons/hicolor/512x512/apps/flowkeeper.png
-
+      - install -Dm644 flowkeeper/res/flowkeeper.png /app/share/icons/hicolor/512x512/apps/org.flowkeeper.Flowkeeper.png
 
       - cd flowkeeper/res; /lib/libexec/rcc -g python --project -o "resources.qrc"
       - cd flowkeeper/res; /lib/libexec/rcc -g python "resources.qrc" -o "../src/fk/desktop/resources.py"
@@ -109,9 +106,9 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/flowkeeper-org/fk-desktop/archive/refs/tags/v0.9.0.tar.gz
+        url: https://github.com/flowkeeper-org/fk-desktop/archive/refs/tags/v0.10.0.tar.gz
         dest: flowkeeper
-        sha256: 82f17b075096a80d5e68041ca6c97b4bcb02f121349014512af30fed1e9538f1
+        sha256: b7003db84d4c77024103642cdb428f8ae2cf559a1f05714eb5b66f8c5a964d5d
 
       - type: script
         commands:

--- a/org.flowkeeper.Flowkeeper.yaml
+++ b/org.flowkeeper.Flowkeeper.yaml
@@ -94,7 +94,6 @@ modules:
 
       - desktop-file-edit --remove-key="Exec" --remove-key="Version" --remove-key="Icon" flowkeeper/installer/flowkeeper.desktop
       - desktop-file-edit --set-key="Exec" --set-value="run.sh" flowkeeper/installer/flowkeeper.desktop
-      - desktop-file-edit --remove-key="Icon" flowkeeper/installer/flowkeeper.desktop
       - install -Dm644 flowkeeper/installer/flowkeeper.desktop ${FLATPAK_DEST}/share/applications/flowkeeper.desktop
       - install -Dm644 flowkeeper/res/flowkeeper.png /app/share/icons/hicolor/512x512/apps/org.flowkeeper.Flowkeeper.png
 


### PR DESCRIPTION
Although I resized the icon file to 512x512, I couldn't make the icon work -- help is needed.

The rest of the changes were implemented directly in Flowkeeper v0.10.0. The GitHub release is in draft mode at the moment, so **this manifest shouldn't be used to push to Flathub** just yet.

I'll summarize the changes to Flowkeeper on this Issue: https://github.com/flowkeeper-org/fk-desktop/issues/63